### PR TITLE
activate current page on navbar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,8 +25,16 @@
     </div>
     <div class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
-        <li class="active"><a href="/ideas">Ideas</a></li>
-        <li class="active"><a href="/pages/info">Info</a></li>
+        <li
+          <% if current_page?(controller: 'ideas') %>
+            class="active"
+          <% end %>
+        ><a href="/ideas">Ideas</a></li>
+        <li
+          <% if current_page? '/pages/info' %>
+            class="active"
+          <% end %>
+        ><a href="/pages/info">Info</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Both "Ideas" and "Info" were activated on navbar. This patch is to change it so that only the current item is activated.